### PR TITLE
feat: define RBAC rules & implement RBAC on auth API routes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,6 +5,7 @@
 	"packages": {
 		"": {
 			"dependencies": {
+				"@casl/ability": "^6.7.3",
 				"@types/jest": "^30.0.0",
 				"@types/node": "^24.0.3",
 				"@types/react": "^19.1.8",
@@ -355,6 +356,18 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@casl/ability": {
+			"version": "6.7.3",
+			"resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.3.tgz",
+			"integrity": "sha512-A4L28Ko+phJAsTDhRjzCOZWECQWN2jzZnJPnROWWHjJpyMq1h7h9ZqjwS2WbIUa3Z474X1ZPSgW0f1PboZGC0A==",
+			"license": "MIT",
+			"dependencies": {
+				"@ucast/mongo2js": "^1.3.0"
+			},
+			"funding": {
+				"url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -1944,6 +1957,41 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@ucast/core": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.2.tgz",
+			"integrity": "sha512-ons5CwXZ/51wrUPfoduC+cO7AS1/wRb0ybpQJ9RrssossDxVy4t49QxWoWgfBDvVKsz9VXzBk9z0wqTdZ+Cq8g==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@ucast/js": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.4.tgz",
+			"integrity": "sha512-TgG1aIaCMdcaEyckOZKQozn1hazE0w90SVdlpIJ/er8xVumE11gYAtSbw/LBeUnA4fFnFWTcw3t6reqseeH/4Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ucast/core": "^1.0.0"
+			}
+		},
+		"node_modules/@ucast/mongo": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.3.tgz",
+			"integrity": "sha512-XcI8LclrHWP83H+7H2anGCEeDq0n+12FU2mXCTz6/Tva9/9ddK/iacvvhCyW6cijAAOILmt0tWplRyRhVyZLsA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ucast/core": "^1.4.1"
+			}
+		},
+		"node_modules/@ucast/mongo2js": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.4.0.tgz",
+			"integrity": "sha512-vR9RJ3BHlkI3RfKJIZFdVktxWvBCQRiSTeJSWN9NPxP5YJkpfXvcBWAMLwvyJx4HbB+qib5/AlSDEmQiuQyx2w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ucast/core": "^1.6.1",
+				"@ucast/js": "^3.0.0",
+				"@ucast/mongo": "^2.4.0"
 			}
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
+		"@casl/ability": "^6.7.3",
 		"@types/jest": "^30.0.0",
 		"@types/node": "^24.0.3",
 		"@types/react": "^19.1.8",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@casl/ability": "^6.7.3",
+				"@casl/mongoose": "^8.0.3",
 				"bcryptjs": "^3.0.1",
 				"compression": "^1.8.0",
 				"cors": "^2.8.5",
@@ -610,6 +612,28 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@casl/ability": {
+			"version": "6.7.3",
+			"resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.3.tgz",
+			"integrity": "sha512-A4L28Ko+phJAsTDhRjzCOZWECQWN2jzZnJPnROWWHjJpyMq1h7h9ZqjwS2WbIUa3Z474X1ZPSgW0f1PboZGC0A==",
+			"license": "MIT",
+			"dependencies": {
+				"@ucast/mongo2js": "^1.3.0"
+			},
+			"funding": {
+				"url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
+			}
+		},
+		"node_modules/@casl/mongoose": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/@casl/mongoose/-/mongoose-8.0.3.tgz",
+			"integrity": "sha512-xK04p4mJBhJX3xppUuH2Z4h+QjM3YvfONct6XEpqvzh4aspTYg7Jn2l1l9er4Ih8sPuPbin947tF/TPYsVO35A==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@casl/ability": "^6.7.0",
+				"mongoose": "^6.0.13 || ^7.0.0 || ^8.0.0"
+			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -3368,6 +3392,41 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@ucast/core": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.2.tgz",
+			"integrity": "sha512-ons5CwXZ/51wrUPfoduC+cO7AS1/wRb0ybpQJ9RrssossDxVy4t49QxWoWgfBDvVKsz9VXzBk9z0wqTdZ+Cq8g==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@ucast/js": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.4.tgz",
+			"integrity": "sha512-TgG1aIaCMdcaEyckOZKQozn1hazE0w90SVdlpIJ/er8xVumE11gYAtSbw/LBeUnA4fFnFWTcw3t6reqseeH/4Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ucast/core": "^1.0.0"
+			}
+		},
+		"node_modules/@ucast/mongo": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.3.tgz",
+			"integrity": "sha512-XcI8LclrHWP83H+7H2anGCEeDq0n+12FU2mXCTz6/Tva9/9ddK/iacvvhCyW6cijAAOILmt0tWplRyRhVyZLsA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ucast/core": "^1.4.1"
+			}
+		},
+		"node_modules/@ucast/mongo2js": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.4.0.tgz",
+			"integrity": "sha512-vR9RJ3BHlkI3RfKJIZFdVktxWvBCQRiSTeJSWN9NPxP5YJkpfXvcBWAMLwvyJx4HbB+qib5/AlSDEmQiuQyx2w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ucast/core": "^1.6.1",
+				"@ucast/js": "^3.0.0",
+				"@ucast/mongo": "^2.4.0"
 			}
 		},
 		"node_modules/@ungap/structured-clone": {

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,8 @@
 	"license": "ISC",
 	"description": "",
 	"dependencies": {
+		"@casl/ability": "^6.7.3",
+		"@casl/mongoose": "^8.0.3",
 		"bcryptjs": "^3.0.1",
 		"compression": "^1.8.0",
 		"cors": "^2.8.5",

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -3,6 +3,7 @@ import { NextFunction, Response } from 'express';
 import User from '@/models/users';
 import { AuthenticatedRequest } from '@/types/auth';
 import { verifyAuthToken } from '@/utils/authTokenHandler';
+import authorizeUser from '@/utils/roleBasedAccess';
 
 //dotenv.config({ path: './.env' });
 
@@ -63,6 +64,9 @@ export async function auth(
 			});
 			return;
 		}
+
+		// Add role authorization to the request
+		req.authorization = authorizeUser(req);
 
 		next();
 	} catch (err: any) {

--- a/server/src/types/auth.ts
+++ b/server/src/types/auth.ts
@@ -1,5 +1,6 @@
 import { Request } from 'express';
 import { JwtPayload } from 'jsonwebtoken';
+import { MongoAbility } from '@casl/ability';
 
 export interface AuthenticatedRequest extends Request {
 	user?: {
@@ -8,6 +9,7 @@ export interface AuthenticatedRequest extends Request {
 		role: string;
 		firstName: string;
 	};
+	authorization?: MongoAbility<any>;
 }
 
 export interface JWTPayload extends JwtPayload {

--- a/server/src/utils/__tests__/roleBasedAccess.test.ts
+++ b/server/src/utils/__tests__/roleBasedAccess.test.ts
@@ -1,0 +1,132 @@
+// server/src/utils/__tests__/roleBasedAccess.test.ts
+import authorizeUser from '@/utils/roleBasedAccess';
+import { AuthenticatedRequest } from '@/types/auth';
+import { subject } from '@casl/ability';
+import { describe, expect, test } from '@jest/globals';
+
+function makeReq(user: Partial<AuthenticatedRequest['user']>): AuthenticatedRequest {
+	return {
+		user: {
+			id: user?.id || '64f000000000000000000001',
+			employeeId: user?.employeeId || 'EMP0001',
+			role: user?.role || 'Volunteer',
+			firstName: user?.firstName || 'Test'
+		}
+	} as AuthenticatedRequest;
+}
+
+const otherUser = {
+	id: '64f000000000000000000002',
+	employeeId: 'EMP0002'
+};
+
+const self = {
+	id: '64f000000000000000000001',
+	employeeId: 'EMP0001'
+};
+
+describe('CASL authorization', () => {
+	describe('Admin', () => {
+		test('Admin can approve other users', () => {
+			const ability = authorizeUser(makeReq({ role: 'Admin', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('approve', subject('User', { _id: otherUser.id }))).toBe(true);
+		});
+
+		test('Admin cannot approve self', () => {
+			const ability = authorizeUser(makeReq({ role: 'Admin', id: self.id, employeeId: self.employeeId }));
+			expect(ability.cannot('approve', subject('User', { _id: self.id }))).toBe(true);
+		});
+
+		test('Admin can read any user', () => {
+			const ability = authorizeUser(makeReq({ role: 'Admin', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('read', subject('User', { _id: otherUser.id }))).toBe(true);
+		});
+
+		test('Admin can update any user', () => {
+			const ability = authorizeUser(makeReq({ role: 'Admin', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('update', subject('User', { _id: otherUser.id }))).toBe(true);
+		});
+
+		test('Admin can create any user', () => {
+			const ability = authorizeUser(makeReq({ role: 'Admin', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('create', subject('User', { _id: otherUser.id }))).toBe(true);
+		});
+
+		test('Admin can delete any user', () => {
+			const ability = authorizeUser(makeReq({ role: 'Admin', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('delete', subject('User', { _id: otherUser.id }))).toBe(true);
+		});
+
+		test('Admin can manage any survey', () => {
+			const ability = authorizeUser(makeReq({ role: 'Admin', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('manage', subject('Survey', { employeeId: otherUser.employeeId }))).toBe(true);
+		});
+
+		test('Admin can delete any survey', () => {
+			const ability = authorizeUser(makeReq({ role: 'Admin', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('delete', subject('Survey', { employeeId: otherUser.employeeId }))).toBe(true);
+		});
+	});
+
+	describe('Manager', () => {
+		test('Manager can approve other users', () => {
+			const ability = authorizeUser(makeReq({ role: 'Manager', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('approve', subject('User', { _id: otherUser.id }))).toBe(true);
+		});
+
+		test('Manager cannot approve self', () => {
+			const ability = authorizeUser(makeReq({ role: 'Manager', id: self.id, employeeId: self.employeeId }));
+			expect(ability.cannot('approve', subject('User', { _id: self.id }))).toBe(true);
+		});
+
+		test('Manager can read any user', () => {
+			const ability = authorizeUser(makeReq({ role: 'Manager', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('read', 'User')).toBe(true);
+		});
+
+		test('Manager can update own profile allowed fields', () => {
+			const ability = authorizeUser(makeReq({ role: 'Manager', id: self.id, employeeId: self.employeeId }));
+			const selfUser = subject('User', { _id: self.id, employeeId: self.employeeId });
+
+			expect(ability.can('update', selfUser, 'firstName')).toBe(true);
+			expect(ability.can('update', selfUser, 'lastName')).toBe(true);
+			expect(ability.can('update', selfUser, 'email')).toBe(true);
+			expect(ability.can('update', selfUser, 'phone')).toBe(true);
+
+			// Not allowed fields
+			expect(ability.cannot('update', selfUser, 'role')).toBe(true);
+			expect(ability.cannot('update', selfUser, 'approvalStatus')).toBe(true);
+		});
+
+		test('Manager can view any survey but only delete their own survey', () => {
+			const ability = authorizeUser(makeReq({ role: 'Manager', id: self.id, employeeId: self.employeeId }));
+			expect(ability.can('read', subject('Survey', { employeeId: otherUser.employeeId }))).toBe(true);
+			expect(ability.can('read', subject('Survey', { employeeId: self.employeeId }))).toBe(true);
+			expect(ability.can('delete', subject('Survey', { employeeId: self.employeeId }))).toBe(true);
+			expect(ability.cannot('delete', subject('Survey', { employeeId: otherUser.employeeId }))).toBe(true);
+		});
+	});
+
+	describe('Volunteer', () => {
+		test('Volunteer can manage only own User limited fields', () => {
+			const id = '64f000000000000000000021';
+			const employeeId = 'EMP0021';
+			const ability = authorizeUser(makeReq({ role: 'Volunteer', id, employeeId }));
+			const selfUser = subject('User', { _id: id, employeeId });
+
+			expect(ability.can('update', selfUser, 'firstName')).toBe(true);
+			expect(ability.can('update', selfUser, 'lastName')).toBe(true);
+			expect(ability.can('update', selfUser, 'email')).toBe(true);
+			expect(ability.can('update', selfUser, 'phone')).toBe(true);
+
+			// Disallowed fields
+			expect(ability.cannot('update', selfUser, 'role')).toBe(true);
+			expect(ability.cannot('update', selfUser, 'approvalStatus')).toBe(true);
+		});
+
+		test('Volunteer cannot approve anyone', () => {
+			const ability = authorizeUser(makeReq({ role: 'Volunteer' }));
+			expect(ability.cannot('approve', subject('User', { _id: otherUser.id }))).toBe(true);
+		});
+	});
+});

--- a/server/src/utils/authTokenHandler.ts
+++ b/server/src/utils/authTokenHandler.ts
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import { Types } from 'mongoose';
 
 // Get the token secret dynamically to support testing environment
 function getTokenSecret(): string {
@@ -15,13 +16,15 @@ function getTokenSecret(): string {
 export function generateAuthToken(
 	firstName: string,
 	role: string,
-	employeeId: string
+	employeeId: string,
+	id: Types.ObjectId
 ): string {
 	return jwt.sign(
 		{
 			firstName: firstName,
 			role: role,
-			employeeId: employeeId
+			employeeId: employeeId,
+			id
 		},
 		getTokenSecret(),
 		{ expiresIn: '12h' }

--- a/server/src/utils/roleBasedAccess.ts
+++ b/server/src/utils/roleBasedAccess.ts
@@ -1,0 +1,67 @@
+import { AbilityBuilder, createMongoAbility, MongoAbility } from '@casl/ability'
+import { AuthenticatedRequest } from '@/types/auth';
+
+// See CASL documentation: https://casl.js.org/v6/en/guide/intro
+
+// Native CASL actions -- CRUD + master action "manage"
+const ACTIONS = { 
+    // Native actions can be used as Mongo query filters with `accessibleBy` function
+    // Note: 'manage' includes ALL actions (native or custom)
+    CASL: { CREATE: 'create', READ: 'read', UPDATE: 'update', DELETE: 'delete', MANAGE: 'manage' },
+    // Custom actions can be used to describe more granular actions instead of just CRUD
+    CUSTOM: { APPROVE: 'approve' }
+}
+
+// Other constants
+const UPDATEABLE_USER_FIELDS = ['firstName', 'lastName', 'email', 'phone'];
+
+// Assigns authorization by role and action
+export default function authorizeUser(req: AuthenticatedRequest): MongoAbility<any> {
+	const { can, cannot, build } = new AbilityBuilder(createMongoAbility);
+	const ctx = { id: req.user?.id || '', employeeId: req.user?.employeeId || '' }; // pass in id and employeeId for context
+
+    switch (req.user?.role) {
+        case 'Admin':
+            adminRules(can);
+            break;
+        case 'Manager':
+            managerRules(can, ctx);
+            break;
+        case 'Volunteer':
+            volunteerRules(can, ctx);
+            break;
+    }
+
+    // Universal rules
+	cannot(ACTIONS.CUSTOM.APPROVE, 'User', { _id: ctx.id });
+
+	return build();
+}
+
+function adminRules(can: any) {
+    // No restrictions
+    can(ACTIONS.CASL.MANAGE, 'User');
+    can(ACTIONS.CASL.MANAGE, 'Survey');
+}
+
+function managerRules(can: any, ctx: { id: string; employeeId: string }) {
+    // User actions
+    can(ACTIONS.CASL.READ, 'User');
+    can(ACTIONS.CASL.MANAGE, 'User', UPDATEABLE_USER_FIELDS, { employeeId: ctx.employeeId });
+    can(ACTIONS.CASL.MANAGE, 'User', UPDATEABLE_USER_FIELDS, { _id: ctx.id });
+    can(ACTIONS.CUSTOM.APPROVE, 'User');
+    
+    // Survey actions
+    can(ACTIONS.CASL.READ, 'Survey');
+    can(ACTIONS.CASL.CREATE, 'Survey');
+    can(ACTIONS.CASL.DELETE, 'Survey', { employeeId: ctx.employeeId });
+}
+
+function volunteerRules(can: any, ctx: { id: string; employeeId: string }) {
+    // User actions
+    can(ACTIONS.CASL.MANAGE, 'User', UPDATEABLE_USER_FIELDS, { employeeId: ctx.employeeId });
+    can(ACTIONS.CASL.MANAGE, 'User', UPDATEABLE_USER_FIELDS, { _id: ctx.id });
+
+    // Survey actions
+    can(ACTIONS.CASL.MANAGE, 'Survey', { employeeId: ctx.employeeId });
+}


### PR DESCRIPTION
<!--
  Pull Request Template
  =====================
  Provide a high-quality, concise description of your changes.
  PRs that follow this template are easier to review and merge.
-->

## 📄 Description

<!-- What does this PR change? Why is it needed? -->

### RBAC updates
Role-based user permissions have been defined using the open-source library [CASL](https://casl.js.org/v6/en/). This library allows us to query our permissions with simple `can` and `cannot` functions when authorization can be derived from the request params or the request body. Additionally, for authorization that is resource-based, our permissions can be passed in as filters into our Mongo queries (see examples of both methods in the authorization logic added to our `/auth/` routes)

A test suite was added to validate the RBAC rules declared for each role.

### Middleware & Token updates
Authorization is derived from user information passed in via the JWT interface. In order to support authorization based on user id (without needing to query our database first), the JWT interface was updated to include the user's ObjectId. This should ideally be streamlined later on, which will be addressed in an upcoming server refactor. Once user-specific permissions are resolved, they are injected into our request and passed on to the handler. As mentioned above, each handler can then check `req.authorization.can` or `req.authorization.cannot` for specific schema and fields, or can pass in an `accessibleBy` filter into its Mongo query



## ✅ Checklist

-   [x] Tests added/updated where needed
-   [ ] Docs added/updated if applicable
-   [ ] I have linked the issue this PR closes (if any)

## 🔗 Related Issues

Resolves #\<issue-number>

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [ ]      |
| ✨ New feature   | [x]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |
| Other (explain)  | [ ]      |

## 🧪 How to test

<!-- Steps reviewers can run to verify functionality -->

```
npm test src/utils/__tests__/roleBasedAccess.test.ts
```

## 📝 Notes to reviewers

<!-- Anything specific reviewers should know before starting -->

- To keep this PR manageable and to allow more fine-grained review of route authorization, only the `/auth/` routes have RBAC implemented. RBAC for `/surveys/` routes will be implemented in a future PR
- Authorization logic will need to be looked at again once our backend schema has been refactored and streamlined -- issues in this PR include needing to support authorization by both `_id` and `employeeId`