### PR TITLE
fix: make surveyCode uniqueness checks async

### DIFF
--- a/server/src/database/survey/survey.controller.ts
+++ b/server/src/database/survey/survey.controller.ts
@@ -23,7 +23,7 @@ export async function getParentSurveyCode(
 export async function generateUniqueChildSurveyCodes(): Promise<Array<string>> {
 	for (let retries = 0; retries < 3; retries++) {
 		const codes = await Promise.all(Array.from({ length: 3 }, () =>
-			generateUniqueReferralCode()
+			generateUniqueSurveyCode()
 		));
 		// Enforce uniqueness within the array
 		if (isUniqueSurveyCodeArray(codes)) {
@@ -51,7 +51,7 @@ function isUniqueSurveyCodeArray(codes: Array<string>): boolean {
  * @returns string - A unique 6-character alphanumeric code in uppercase
  * @throws {Error} - Throws SURVEY_CODE_GENERATION_ERROR if unable to generate unique code after 3 retries
  */
-export async function generateUniqueReferralCode(): Promise<string> {
+export async function generateUniqueSurveyCode(): Promise<string> {
 	for (let retries = 0; retries < 3; retries++) {
 		const code = Math.random().toString(36).substring(2, 8).toUpperCase();
 		// Enforce individual code uniqueness

--- a/server/src/routes/v2/surveys.ts
+++ b/server/src/routes/v2/surveys.ts
@@ -5,7 +5,7 @@ import express, { NextFunction, Response } from 'express';
 import Survey, { ISurvey } from '@/database/survey/mongoose/survey.model';
 import {
 	generateUniqueChildSurveyCodes,
-	generateUniqueReferralCode,
+	generateUniqueSurveyCode,
 	getParentSurveyCode
 } from '@/database/survey/survey.controller';
 import {
@@ -230,7 +230,7 @@ router.post(
 			} else if (req.query.new === 'true') {
 				// If `new` query parameter is true, generate new survey code and set parent to seed
 				surveyData.parentSurveyCode = SYSTEM_SURVEY_CODE;
-				surveyData.surveyCode = await generateUniqueReferralCode();
+				surveyData.surveyCode = await generateUniqueSurveyCode();
 			} else {
 				const err = errors.NO_SURVEY_CODE_PROVIDED;
 				return res.status(err.status).json({


### PR DESCRIPTION
<!--
  Pull Request Template
  =====================
  Provide a high-quality, concise description of your changes.
  PRs that follow this template are easier to review and merge.
-->

## 📄 Description

<!-- What does this PR change? Why is it needed? -->

- This PR fixes a bug where referral code generation always failed with 'unable to generate code.' The uniqueness check compared unresolved Promises to null, so it always returned false.
  - made `isUniqueSurveyCode`, `generateUniqueSurveyCode`, and `generateUniqueChildSurveyCodes` async for database checks
  - updated call sites to `await` generation in Survey routes
- This PR also changed `generateUniqueReferralCode` to `generateUniqueSurveyCode` to unify naming convention. 
- These changes will need to be reflected in https://github.com/uw-ssec/respondent-driven-sampling/pull/93 once merged.

## ✅ Checklist

-   [ ] Tests added/updated where needed
-   [ ] Docs added/updated if applicable
-   [ ] I have linked the issue this PR closes (if any)

## 🔗 Related Issues

N/A

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [x]      |
| ✨ New feature   | [ ]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |
| Other (explain)  | [ ]      |

## 🧪 How to test

<!-- Steps reviewers can run to verify functionality -->

Tested by hitting API endpoints

## 📝 Notes to reviewers

<!-- Anything specific reviewers should know before starting -->
