### PR TITLE
chore: Auth flow improvements

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,17 +1,20 @@
+import { ProtectedRoute } from '@/components';
 import { AuthProvider } from '@/contexts';
 import {
-	Survey,
-	SurveyDetails,
-	SurveyEntryDashboard,
-	QrPage,
+	ApplyReferral,
 	LandingPage,
 	Login,
+	NewUser,
 	Profile,
-	ApplyReferral,
+	QrPage,
 	Signup,
 	StaffDashboard,
-	NewUser
+	Survey,
+	SurveyDetails,
+	SurveyEntryDashboard
 } from '@/pages';
+import { muiTheme } from '@/theme/muiTheme';
+import { isTokenValid } from '@/utils/authTokenHandler';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import {
@@ -20,9 +23,6 @@ import {
 	BrowserRouter as Router,
 	Routes
 } from 'react-router-dom';
-import { ProtectedRoute } from '@/components';
-import { muiTheme } from '@/theme/muiTheme';
-import { isTokenValid } from '@/utils/authTokenHandler';
 
 function App() {
 	return (
@@ -31,7 +31,17 @@ function App() {
 				<CssBaseline />
 				<Router>
 					<Routes>
-						<Route path="/" element={<Navigate replace to={isTokenValid() ? '/dashboard' : '/login'} />} />
+						<Route
+							path="/"
+							element={
+								<Navigate
+									replace
+									to={
+										isTokenValid() ? '/dashboard' : '/login'
+									}
+								/>
+							}
+						/>
 						<Route path="/login" element={<Login />} />
 						<Route
 							path="/survey/:id/continue"

--- a/client/src/components/forms/FormInput.tsx
+++ b/client/src/components/forms/FormInput.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import { TextField, TextFieldProps } from '@mui/material';
 
 import { PermissionTooltip } from './PermissionTooltip';
@@ -20,13 +21,19 @@ export const FormInput = ({
 }: FormInputProps) => {
 	const [touched, setTouched] = useState(false);
 
-	const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+	const handleBlur = (
+		e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>
+	) => {
 		setTouched(true);
 		onBlur?.(e);
 	};
 
 	// Show error if required and value is empty, but only after field has been touched
-	const hasError = error || (touched && required && (!value || (typeof value === 'string' && !value.trim())));
+	const hasError =
+		error ||
+		(touched &&
+			required &&
+			(!value || (typeof value === 'string' && !value.trim())));
 
 	const input = (
 		<TextField
@@ -36,7 +43,10 @@ export const FormInput = ({
 			error={hasError}
 			onBlur={handleBlur}
 			helperText={
-				hasError && touched && required && (!value || (typeof value === 'string' && !value.trim()))
+				hasError &&
+				touched &&
+				required &&
+				(!value || (typeof value === 'string' && !value.trim()))
 					? 'This field is required'
 					: helperText
 			}

--- a/client/src/components/forms/FormSelect.tsx
+++ b/client/src/components/forms/FormSelect.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import {
 	FormControl,
 	FormHelperText,
@@ -43,7 +44,12 @@ export const FormSelect = ({
 	const hasError = error || (touched && required && !value);
 
 	const selectControl = (
-		<FormControl fullWidth error={hasError} required={required} disabled={!canEdit}>
+		<FormControl
+			fullWidth
+			error={hasError}
+			required={required}
+			disabled={!canEdit}
+		>
 			<InputLabel id={labelId}>{label}</InputLabel>
 			<Select
 				{...props}
@@ -67,7 +73,9 @@ export const FormSelect = ({
 			{hasError && touched && required && !value && (
 				<FormHelperText>This field is required</FormHelperText>
 			)}
-			{helperText && !hasError && <FormHelperText>{helperText}</FormHelperText>}
+			{helperText && !hasError && (
+				<FormHelperText>{helperText}</FormHelperText>
+			)}
 		</FormControl>
 	);
 

--- a/client/src/components/forms/PhoneInput.tsx
+++ b/client/src/components/forms/PhoneInput.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+
 import { TextField, TextFieldProps } from '@mui/material';
 
 import { PermissionTooltip } from './PermissionTooltip';
-import { useState } from 'react';
 
 interface PhoneInputProps extends Omit<TextFieldProps, 'variant' | 'type'> {
 	canEdit?: boolean;
@@ -19,7 +20,9 @@ export const PhoneInput = ({
 }: PhoneInputProps) => {
 	const [touched, setTouched] = useState(false);
 
-	const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+	const handleBlur = (
+		e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>
+	) => {
 		setTouched(true);
 		onBlur?.(e);
 	};
@@ -49,8 +52,8 @@ export const PhoneInput = ({
 		onChange(syntheticEvent as React.ChangeEvent<HTMLInputElement>);
 	};
 
-	const hasError = (touched && (!value || (typeof value === 'string' && !value.trim())));
-
+	const hasError =
+		touched && (!value || (typeof value === 'string' && !value.trim()));
 
 	const input = (
 		<TextField
@@ -59,7 +62,9 @@ export const PhoneInput = ({
 			value={value ?? ''}
 			error={hasError}
 			helperText={
-				hasError && touched && (!value || (typeof value === 'string' && !value.trim()))
+				hasError &&
+				touched &&
+				(!value || (typeof value === 'string' && !value.trim()))
 					? 'This field is required'
 					: helperText
 			}

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useSurveyStore } from '@/stores';
+import { deleteAuthToken, isTokenValid } from '@/utils/authTokenHandler';
 import {
 	Alert,
 	Box,
@@ -12,10 +13,6 @@ import {
 import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '@/hooks/useAuth';
-import {
-	deleteAuthToken,
-	isTokenValid
-} from '@/utils/authTokenHandler';
 
 export default function Login() {
 	const { handleLogin } = useAuth();

--- a/client/src/pages/Signup/Signup.tsx
+++ b/client/src/pages/Signup/Signup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { deleteAuthToken, isTokenValid } from '@/utils/authTokenHandler';
 import { Alert, Box, Button, Link, Stack, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 
@@ -9,10 +10,6 @@ import {
 	PhoneInput,
 	RoleSelect
 } from '@/components/forms';
-import {
-	deleteAuthToken,
-	isTokenValid
-} from '@/utils/authTokenHandler';
 
 export default function Signup() {
 	const navigate = useNavigate();
@@ -78,7 +75,9 @@ export default function Signup() {
 			} else {
 				// Extract individual error messages from validation errors
 				if (data.errors && Array.isArray(data.errors)) {
-					const messages = data.errors.map((err: { message: string }) => err.message);
+					const messages = data.errors.map(
+						(err: { message: string }) => err.message
+					);
 					setErrorMessages(messages);
 				} else {
 					setErrorMessages([data.message || 'Failed to send OTP']);
@@ -107,7 +106,9 @@ export default function Signup() {
 			} else {
 				// Extract individual error messages from validation errors
 				if (data.errors && Array.isArray(data.errors)) {
-					const messages = data.errors.map((err: { message: string }) => err.message);
+					const messages = data.errors.map(
+						(err: { message: string }) => err.message
+					);
 					setErrorMessages(messages);
 				} else {
 					setErrorMessages([data.message || 'Failed to verify OTP']);
@@ -117,7 +118,6 @@ export default function Signup() {
 			setErrorMessages(['Failed to verify OTP']);
 		}
 	};
-
 
 	return (
 		<Box
@@ -158,12 +158,17 @@ export default function Signup() {
 				{signupSuccess && pendingApproval ? (
 					<Stack spacing={2.5}>
 						<Alert severity="info" sx={{ mb: 2 }}>
-							Your account has been created successfully! However, your account
-							is pending approval from an administrator.
+							Your account has been created successfully! However,
+							your account is pending approval from an
+							administrator.
 						</Alert>
-						<Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-							Once your account has been approved, please log back in to access
-							the application.
+						<Typography
+							variant="body2"
+							color="text.secondary"
+							sx={{ mb: 2 }}
+						>
+							Once your account has been approved, please log back
+							in to access the application.
 						</Typography>
 						<Button
 							variant="contained"

--- a/client/src/stores/useAuthStore.tsx
+++ b/client/src/stores/useAuthStore.tsx
@@ -9,7 +9,7 @@ type AuthStore = {
 
 export const useAuthStore = create<AuthStore>()(
 	persist(
-		(set) => ({
+		set => ({
 			token: '',
 			setToken: (token: string) => set({ token }),
 			clearToken: () => set({ token: '' })
@@ -17,14 +17,14 @@ export const useAuthStore = create<AuthStore>()(
 		{
 			name: 'auth-storage',
 			storage: {
-				getItem: (name) => {
+				getItem: name => {
 					const value = sessionStorage.getItem(name);
 					return value ? JSON.parse(value) : null;
 				},
 				setItem: (name, value) => {
 					sessionStorage.setItem(name, JSON.stringify(value));
 				},
-				removeItem: (name) => {
+				removeItem: name => {
 					sessionStorage.removeItem(name);
 				}
 			}

--- a/client/src/utils/authTokenHandler.ts
+++ b/client/src/utils/authTokenHandler.ts
@@ -39,7 +39,7 @@ export function hasAuthToken(): boolean {
 export function isTokenValid(): boolean {
 	const token = getAuthToken();
 	if (!token) return false;
-	
+
 	try {
 		const decoded = jwtDecode<JwtPayload & { exp?: number }>(token);
 		// Check if token has expiration and if it's expired

--- a/server/src/database/user/zod/auth.validator.ts
+++ b/server/src/database/user/zod/auth.validator.ts
@@ -32,4 +32,3 @@ export const verifyOtpLoginSchema = createUserSchema
 		code: otpCodeSchema
 	})
 	.strict();
-

--- a/server/src/database/user/zod/user.base.ts
+++ b/server/src/database/user/zod/user.base.ts
@@ -13,10 +13,13 @@ export const baseUserSchema = z
 	.object({
 		firstName: z.string().min(1, 'First name is required'),
 		lastName: z.string().min(1, 'Last name is required'),
-		email: z.email({message: 'Please provide a valid email address'}),
+		email: z.email({ message: 'Please provide a valid email address' }),
 		phone: z
 			.string()
-			.regex(/^\+1\d{10}$/, 'Please provide a valid 10-digit phone number with country code (+1XXXXXXXXXX)'),
+			.regex(
+				/^\+1\d{10}$/,
+				'Please provide a valid 10-digit phone number with country code (+1XXXXXXXXXX)'
+			),
 		role: z.enum(ROLE_ENUM, {
 			message: 'Please provide a valid role'
 		}),
@@ -25,16 +28,10 @@ export const baseUserSchema = z
 		}),
 		approvedByUserObjectId: z
 			.string()
-			.refine(
-				Types.ObjectId.isValid,
-				'Please provide a valid user ID'
-			),
+			.refine(Types.ObjectId.isValid, 'Please provide a valid user ID'),
 		locationObjectId: z
 			.string()
-			.refine(
-				Types.ObjectId.isValid,
-				'Please provide a valid location'
-			),
+			.refine(Types.ObjectId.isValid, 'Please provide a valid location'),
 		permissions: z.array(
 			z.object({
 				action: z.enum(ACTION_ENUM),

--- a/server/src/routes/v1/auth.ts
+++ b/server/src/routes/v1/auth.ts
@@ -4,15 +4,15 @@ import twilio from 'twilio';
 import { z } from 'zod';
 
 import User from '@/database/user/mongoose/user.model';
-import { ApprovalStatus } from '@/database/utils/constants';
-import { generateAuthToken } from '@/utils/authTokenHandler';
-import { validate } from '@/middleware/validate';
 import {
 	sendOtpLoginSchema,
 	sendOtpSignupSchema,
 	verifyOtpLoginSchema,
 	verifyOtpSignupSchema
 } from '@/database/user/zod/auth.validator';
+import { ApprovalStatus } from '@/database/utils/constants';
+import { validate } from '@/middleware/validate';
+import { generateAuthToken } from '@/utils/authTokenHandler';
 
 const router = express.Router();
 


### PR DESCRIPTION
<!--
  Pull Request Template
  =====================
  Provide a high-quality, concise description of your changes.
  PRs that follow this template are easier to review and merge.
-->

## 📄 Description

### Sign-up improvements
- Now have `auth.validator.ts` to constrain sign up form inputs (require valid phone/email, required name/role/location. These schema extend`baseUserSchema` requirements.
  - Previously, users could enter invalid or empty fields and still move onto the OTP verification phase. Once verified, the client would try to create a new user with invalid fields, which would return a "failure to verify" error despite it actually being a database error 
- Added client-side `required` constraints on form fields to reinforce server-side Zod requirements as well. These were not being truly enforced in our components
- Updated Zod error messages to be more user-friendly when exposed on UI:
<img width="452" height="724" alt="Screenshot 2025-11-14 at 3 20 59 PM" src="https://github.com/user-attachments/assets/ceb9ce8b-05f6-40ab-8d3f-0e6e1c7c326c" />

- Sign up redirects:
  - Because it's never the case the a newly signed up user will be approved, removed redirect to dashboard. Intead, users now will see an informative widget:
<img width="639" height="466" alt="Screenshot 2025-11-14 at 3 14 48 PM" src="https://github.com/user-attachments/assets/91051859-e21c-4d4e-a134-d43372eca12a" />

  - If there truly is a server error, the alert remains the same:
<img width="629" height="525" alt="Screenshot 2025-11-14 at 3 16 38 PM" src="https://github.com/user-attachments/assets/c059451d-bf04-40e0-b7a9-b4946df347f5" />

### Log-in improvements
- Log in has remained functionally the same, with minor improvements:
  - Use Zod validation provided by `auth.validator.ts` for phone/email input (email optional at this point, but still supported if we ever change back to old format)
  - Use MUI `Alert` components for error/success messages on UI

### Auth session improvements
- Moved auth store to `sessionStorage` instead of `localStorage`. This allows the browser to handle high-level auth token persistence by deleting auth token information once a user closes the tab/window. It also forces a user to log in again any time they are opening a fresh tab/window
  - Auth store is still cleared manually when a user logs out 
  - Couldn't work out an elegant solution for if a user navigates away from our domain specifically, then tries to come back within the same tab (i.e. they are still logged in if navigate away) -- may want to consider a tighter JWT expiration?

### Misc
- Removed old `auth` routes; will do full v1/v2 flattening migration in a future PR 

<!-- What does this PR change? Why is it needed? -->

## ✅ Checklist

-   [ ] Tests added/updated where needed
-   [ ] Docs added/updated if applicable
-   [ ] I have linked the issue this PR closes (if any)

## 🔗 Related Issues

Resolves #\<issue-number>

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [x]      |
| ✨ New feature   | [ ]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |
| Other (explain)  | [ ]      |

## 🧪 How to test

<!-- Steps reviewers can run to verify functionality -->

## 📝 Notes to reviewers

<!-- Anything specific reviewers should know before starting -->
