### PR TITLE
fix: capture objectId of the user that approved the user

### DIFF
--- a/client/src/hooks/useApi.tsx
+++ b/client/src/hooks/useApi.tsx
@@ -72,12 +72,13 @@ export const useApi = () => {
 
 	const approveUser = async (
 		userObjectId: string,
-		approvalStatus: string
+		approvalStatus: string,
+		approvedByUserObjectId: string
 	) => {
 		const response = await fetchWithAuth(`/api/v2/users/${userObjectId}`, {
 			method: 'PATCH',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ approvalStatus })
+			body: JSON.stringify({ approvalStatus, approvedByUserObjectId })
 		});
 		return response?.json();
 	};

--- a/client/src/pages/StaffDashboard/StaffDashboard.tsx
+++ b/client/src/pages/StaffDashboard/StaffDashboard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useAuthContext } from '@/contexts';
 import { useApi } from '@/hooks';
 import { Box, Paper, TablePagination, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
@@ -23,6 +24,7 @@ interface StaffMember {
 export default function StaffDashboard() {
 	const navigate = useNavigate();
 	const { userService } = useApi();
+	const { userObjectId } = useAuthContext();
 	const [searchTerm, setSearchTerm] = useState('');
 	const [filterRole, setFilterRole] = useState('');
 	const [currentPage, setCurrentPage] = useState(0); // MUI uses 0-based index
@@ -40,7 +42,11 @@ export default function StaffDashboard() {
 	// Handlers
 	const handleApproval = async (id: string, status: string) => {
 		try {
-			const response = await userService.approveUser(id, status);
+			const response = await userService.approveUser(
+				id,
+				status,
+				userObjectId
+			);
 			if (!response) return;
 			mutate(); // Refresh the list
 		} catch (err) {


### PR DESCRIPTION
Under the Staff Dashboard, admins or users with privileges could approve other users, but the `approvedByUserObjectId` field was not being populated. 