### PR TITLE
Add KCRHA PIT Count 2026 survey locations

### DIFF
--- a/server/src/scripts/locations.yaml
+++ b/server/src/scripts/locations.yaml
@@ -1,0 +1,139 @@
+# KCRHA Point-in-Time Count Survey Locations
+# Import with: npm run location -- import src/scripts/locations.yaml
+
+# Seattle Locations
+- hubName: 'Opportunity Center at North Seattle College'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '9600 College Way N, Seattle, WA 98103'
+
+- hubName: 'YouthCare Orion Center (Use Entrance on Stewart St.)'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '1828 Yale Ave, Seattle, WA 98101'
+
+- hubName: 'Lake City Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '12501 28th Ave NE, Seattle, WA 98125'
+
+- hubName: 'Compass Day Center'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '210 Alaskan Way , Seattle, WA 98104'
+
+- hubName: 'SVdP Georgetown Foodbank'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '5972 4th Ave S, Seattle, WA 98108'
+
+- hubName: 'St. James Cathedral'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '804 9th Ave, Seattle, WA 98104'
+
+- hubName: 'South Lucile Street VA Center'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '305 S Lucile St, STE 103, Seattle, WA 98104'
+
+- hubName: 'Allen Family Center (Families with Children Only)'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '3190 Martin Luther King Jr Way S, Seattle, WA 98144'
+
+- hubName: 'Southwest Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '9010 35th Ave SW, Seattle, WA 98126'
+
+- hubName: 'South Park Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '8604 8th Ave S, Seattle, WA 98108'
+
+# North King County Locations
+- hubName: 'Shoreline Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '345 NE 175th St, Shoreline, WA 98155'
+
+- hubName: 'Ronald United Methodist Church'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '17839 Aurora Ave N, Shoreline, WA 98133'
+
+# East King County Locations
+- hubName: 'Overlake Christian Church'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '9900 Willows Rd. NE, Redmond, WA 98052'
+
+- hubName: 'Kirkland Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '308 Kirkland Ave, Kirkland, WA 98033'
+
+- hubName: 'Issaquah Community Hall'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '180 E Sunset Way, Issaquah, WA 98027'
+
+- hubName: 'Bellevue Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '111 110th Ave NE, Bellevue, WA 98004'
+
+# Snoqualmie Valley Locations
+- hubName: 'Reclaim'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '8224 Railroad Ave, Snoqualmie, WA 98065'
+
+- hubName: 'North Bend Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '115 E 4th St, North Bend, WA 98045'
+
+# Southeast King County Locations
+- hubName: 'Plateau Outreach Ministries'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '1806 Cole St, Enumclaw, WA 98022'
+
+- hubName: 'Maple Valley Food Bank'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '21415 Renton-Maple Valley Rd, Maple Valley, WA 98038'
+
+# South King County Locations
+- hubName: 'Renton Highlands Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '2801 NE 10th St, Renton, WA 98056'
+
+- hubName: 'Kent Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '212 2nd Ave N, Kent, WA 98032'
+
+- hubName: 'Highline United Methodist Church'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '13015 1st Ave S, Burien, WA 98168'
+
+- hubName: 'Federal Way Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '34200 1st Way S, Federal Way, WA 98003'
+
+# Vashon Locations
+- hubName: 'Vashon Island Library'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '17210 Vashon Hwy SW, Vashon, WA 98070'
+
+- hubName: 'Vashon Maury Community Food Bank'
+  hubType: ESTABLISHMENT
+  locationType: ROOFTOP
+  address: '17210 Vashon Hwy SW, Vashon, WA 98070'


### PR DESCRIPTION
## 📄 Description

This PR adds a comprehensive locations.yaml file containing all 27 KCRHA Point-in-Time Count survey locations across King County for the 2026 count.

**Locations organized by region:**
- Seattle: 10 locations
- North King County: 2 locations
- East King County: 4 locations
- Snoqualmie Valley: 2 locations
- Southeast King County: 2 locations
- South King County: 4 locations
- Vashon: 2 locations

**Location Configuration:**
- hubType: ESTABLISHMENT (specific buildings)
- locationType: ROOFTOP (precise address-level accuracy)
- All addresses sourced from seed_templates.json

**Import Command:**
```bash
npm run location -- import src/scripts/locations.yaml
```

## ✅ Checklist

-   [ ] Tests added/updated where needed
-   [x] Docs added/updated if applicable
-   [x] I have linked the issue this PR closes (if any)

## 🔗 Related Issues

https://github.com/uw-ssec/respondent-driven-sampling/issues/144 

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [ ]      |
| ✨ New feature   | [x]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |
| Other (explain)  | [ ]      |

## 🧪 How to test

1. Import the locations into the database:
   ```bash
   npm run location -- import src/scripts/locations.yaml
   ```

2. Verify all 27 locations were imported successfully

3. Check that each location has:
   - Correct hubName matching the facility name
   - Complete address
   - hubType set to ESTABLISHMENT
   - locationType set to ROOFTOP

4. Test seed generation with imported locations:
   ```bash
   npm run generate-seeds -- "Opportunity Center at North Seattle College" 150 seattle
   ```

## 📝 Notes to reviewers

- These locations are already imported to the new database.