### PR TITLE
Fix second gift card visibility to check all household members

### DIFF
--- a/client/src/pages/Survey/utils/survey.json
+++ b/client/src/pages/Survey/utils/survey.json
@@ -1,5 +1,11 @@
 {
   "title": "Unsheltered Point-in-Time Count 2026",
+  "calculatedValues": [
+    {
+      "name": "has_minor_child",
+      "expression": "countInArray({household_members}, 'hh_member_age', {hh_member_age} anyof ['0-6 years old', '7-12 years old', '13-17 years old']) > 0"
+    }
+  ],
   "pages": [
     {
       "name": "volunteer-pre-screen",
@@ -1491,7 +1497,7 @@
         {
           "type": "text",
           "name": "gift_card_2",
-          "visibleIf": "{gift_card_check} = 'Yes' and {household_members[0].hh_member_age} anyof ['0-6 years old', '7-12 years old', '13-17 years old']",
+          "visibleIf": "{gift_card_check} = 'Yes' and {has_minor_child} = true",
           "title": "Please enter the last 4 digits of the 2nd Gift Card:",
           "description": "Note: Families with minor children receive two gift cards.",
           "inputType": "number",


### PR DESCRIPTION
Previously, the second gift card field only appeared when the first household member was a minor (ages 0-6, 7-12, or 13-17). This caused the field to not appear when minors were at other positions in the household_members array.

Added a calculatedValue "has_minor_child" that uses countInArray to check if ANY household member is a minor, not just the first one. Updated the gift_card_2 visibleIf condition to use this calculated value.

<!--
  Pull Request Template
  =====================
  Provide a high-quality, concise description of your changes.
  PRs that follow this template are easier to review and merge.
-->

## 📄 Description

<!-- What does this PR change? Why is it needed? -->

Previously, the second gift card field only appeared when the first
household member was a minor (ages 0-6, 7-12, or 13-17). This caused
the field to not appear when minors were at other positions in the
household_members array.

Added a calculatedValue "has_minor_child" that uses countInArray to
check if ANY household member is a minor, not just the first one.
Updated the gift_card_2 visibleIf condition to use this calculated value.

## ✅ Checklist

-   [ ] Tests added/updated where needed
-   [ ] Docs added/updated if applicable
-   [ ] I have linked the issue this PR closes (if any)

## 🔗 Related Issues

Resolves #\<issue-number>

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [ ]      |
| ✨ New feature   | [ ]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |
| Other (explain)  | [ ]      |

## 🧪 How to test

<!-- Steps reviewers can run to verify functionality -->

## 📝 Notes to reviewers

<!-- Anything specific reviewers should know before starting -->
