### PR TITLE
chore: Update copyright year in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024 University of Washington, eScience Institute, Scientific Software Engineering Center
+Copyright (c) 2026 University of Washington, eScience Institute, Scientific Software Engineering Center
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This pull request updates the copyright year in the `LICENSE` file to reflect the current year.

* Updated the copyright year from 2024 to 2026 in the `LICENSE` file.